### PR TITLE
Return index progress of 0 as soon as the indexing has started

### DIFF
--- a/library.js
+++ b/library.js
@@ -619,9 +619,14 @@ Solr.rebuildUserIndex = function(callback) {
 };
 
 Solr.getIndexProgress = function(req, res) {
-	if (Solr.indexStatus.running && Solr.indexStatus.total > 0) {
-		var progress = (Solr.indexStatus.current / Solr.indexStatus.total).toFixed(4) * 100;
-		res.status(200).send(progress.toString());
+	if (Solr.indexStatus.running) {
+		if(Solr.indexStatus.total > 0) {
+			var progress = (Solr.indexStatus.current / Solr.indexStatus.total).toFixed(4) * 100;
+			res.status(200).send(progress.toString());
+		}
+		else {
+			res.status(200).send("0");
+		}
 	} else {
 		res.status(200).send('-1');
 	}


### PR DESCRIPTION
I have a forum with a lot of posts and even only calculating the amount of posts the forum has takes up to a minute. What would happen is that the browser would check for the progress but immediately receive an answer of `-1` and thus assuming the indexing finished. When in reality the `indexStatus.running` was set to `true` but `indexStatus.total` was still at `0` since it wasn't able to calculate yet.