### PR TITLE
Batched index rebuilding

### DIFF
--- a/library.js
+++ b/library.js
@@ -597,7 +597,7 @@ Solr.rebuildTopicIndex = function(callback) {
 
 				Solr.add(payload, function (err) {
 					if(!err) {
-						var progressPercent = (indexedTopicCount / topics.length).toFixed(2);
+						var progressPercent = (100 * indexedTopicCount / topics.length).toFixed(2);
 						winston.info("[plugins/solr/reindexTopic] Partial re-indexing completed: " + progressPercent + "%")
 					}
 


### PR DESCRIPTION
As mentioned in issue #36 you run into memory problems with the current implementation when rebuilding the entire index on large forums. This code will process the topics in batches of 1000 and add them to the Solr server.

It is a very simple implementation that gets the job done on my server. Not sure if this is good enough for general usage thus I might suggest a critical look at it :smiley: 