### PR TITLE
Batch collecting topic meta data instead of in one big go

### DIFF
--- a/library.js
+++ b/library.js
@@ -14,6 +14,7 @@ var db = module.parent.require('./database'),
 	topics = module.parent.require('./topics'),
 	posts = module.parent.require('./posts'),
 	user = module.parent.require('./user'),
+	batch = module.parent.require('./batch'),
 	utils = require('./lib/utils'),
 
 	Solr = {
@@ -559,79 +560,73 @@ Solr.rebuildIndex = function(req, res) {
 
 Solr.rebuildTopicIndex = function(callback) {
 	async.waterfall([
-		async.apply(db.getSortedSetRange, 'topics:tid', 0, -1),
-		function(tids, next) {
-			var index = 0;
+		function (next) {
 			var topicsFields = [];
-			async.whilst(function () {
-				return index < tids.length;
-			},
-			function (callback) {
-				var slicedTids = tids.slice(index, index + 1000);
-				topics.getTopicsFields(slicedTids, ['tid', 'mainPid', 'title', 'cid', 'uid', 'deleted'], function (err, results) {
+			batch.processSortedSet('topics:tid', function (tids, callback) {
+				topics.getTopicsFields(tids, ['tid', 'mainPid', 'title', 'cid', 'uid', 'deleted'], function (err, results) {
 					if(!err) {
-						index += results.length;
 						topicsFields = topicsFields.concat(results);
 					}
 
 					callback(err);
 				});
-			},
-			function (err) {
-				next(err, topicsFields);
-			});
-		}
-	], function(err, topics) {
-		if (err) {
-			winston.error('[plugins/solr/reindexTopic] Could not retrieve topic listing for indexing. Error: ' + err.message);
-			return callback(err);
-		}
-
-		var indexedTopicCount = 0;
-		async.whilst(function () {
-			return indexedTopicCount < topics.length;
-		},
-		function (callback) {
-			var indexingTopics = topics.slice(indexedTopicCount, indexedTopicCount + 1000);
-			async.mapLimit(indexingTopics, 100, Solr.indexTopic, function(err, topicPayloads) {
-				if (err) {
-					winston.error('[plugins/solr/reindexTopic] Could not retrieve topic content for indexing. Error: ' + err.message);
-					return callback(err);
+			}, function (err) {
+				if(err) {
+					winston.error('[plugins/solr/reindexTopic] Could not retrieve topic listing for indexing. Error: ' + err.message);
 				}
 
-				// Normalise and validate the entries before they're added to Solr
-				var payload = topicPayloads.reduce(function(currentPayload, topics) {
-					if (Array.isArray(topics)) {
-						return currentPayload.concat(topics);
-					} else {
-						currentPayload.push(topics);
-						return currentPayload;
-					}
-				}, []).filter(function(entry) {
-					return entry && entry.hasOwnProperty('id');
-				});
-
-				indexedTopicCount += indexingTopics.length;
-
-				Solr.add(payload, function (err) {
-					if(!err) {
-						var progressPercent = (100 * indexedTopicCount / topics.length).toFixed(2);
-						winston.info("[plugins/solr/reindexTopic] Partial re-indexing completed: " + progressPercent + "%")
-					}
-
-					callback(err);
-				})
+				next(err, topicsFields);
 			});
 		},
-		function (err) {
-			if (typeof callback === 'function') {
-				callback(err, []);
-			} else if (!err) {
-				winston.info('[plugins/solr/reindexTopic] Topic re-indexing completed.');
-			} else {
-				winston.error('[plugins/solr/reindexTopic] Could not insert data into Solr for indexing. Error: ' + err.message);
-			}
-		});
+		function(topics, next) {
+			var indexedTopicCount = 0;
+			async.whilst(
+				function () {
+					return indexedTopicCount < topics.length;
+				},
+				function (callback) {
+					var indexingTopics = topics.slice(indexedTopicCount, indexedTopicCount + 1000);
+					async.mapLimit(indexingTopics, 100, Solr.indexTopic, function (err, topicPayloads) {
+						if (err) {
+							winston.error('[plugins/solr/reindexTopic] Could not retrieve topic content for indexing. Error: ' + err.message);
+							return callback(err);
+						}
+
+						// Normalise and validate the entries before they're added to Solr
+						var payload = topicPayloads.reduce(function (currentPayload, topics) {
+							if (Array.isArray(topics)) {
+								return currentPayload.concat(topics);
+							} else {
+								currentPayload.push(topics);
+								return currentPayload;
+							}
+						}, []).filter(function (entry) {
+							return entry && entry.hasOwnProperty('id');
+						});
+
+						indexedTopicCount += indexingTopics.length;
+
+						Solr.add(payload, function (err) {
+							if (!err) {
+								var progressPercent = (100 * indexedTopicCount / topics.length).toFixed(2);
+								winston.info("[plugins/solr/reindexTopic] Partial re-indexing completed: " + progressPercent + "%")
+							}
+
+							callback(err);
+						})
+					});
+				},
+				next);
+		}
+	],
+	function (err) {
+		if (typeof callback === 'function') {
+			callback(err, []);
+		} else if (!err) {
+			winston.info('[plugins/solr/reindexTopic] Topic re-indexing completed.');
+		} else {
+			winston.error('[plugins/solr/reindexTopic] Could not insert data into Solr for indexing. Error: ' + err.message);
+		}
 	});
 };
 


### PR DESCRIPTION
I ran into issues when there are a lot of topics and limited memory. It resulted in the MongoDB query running for very long times and thus timing out. Batching it makes it run without any problems.

Review as necessary. I tested it on a forum with >2 mio posts and >200,000 topics.