### PR TITLE
Updated solr-client to 0.7.0 and lru-cache to 4.1.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,8 +23,8 @@
   },
   "readmeFilename": "README.md",
   "dependencies": {
-    "solr-client": "^0.5.0",
-    "lru-cache": "^2.5.0"
+    "solr-client": "^0.7.0",
+    "lru-cache": "^4.1.2"
   },
   "nbbpm": {
     "compatibility": "^1.5.0"


### PR DESCRIPTION
As the title says it updates dependencies to their latest versions. Especially in solr-client are security fixes via using a newer request module. There are no incompatibilities as far as I could tell. And all my tests still worked fine as before.