### PR TITLE
Rebuild index no add when error

### DIFF
--- a/library.js
+++ b/library.js
@@ -546,14 +546,18 @@ Solr.rebuildIndex = function(req, res) {
 	}, function(err, results) {
 		var payload = results.topics.concat(results.users);
 
-		Solr.add(payload, function(err) {
-			if (!err) {
-				winston.info('[plugins/solr] Re-indexing completed.');
-				Solr.indexStatus.running = false;
-			} else {
-				winston.error('[plugins/solr] Could not retrieve topic listing for indexing. Error: ' + err.message);
-			}
-		});
+		if(!err) {
+			Solr.add(payload, function (err) {
+				if (!err) {
+					winston.info('[plugins/solr] Re-indexing completed.');
+					Solr.indexStatus.running = false;
+				} else {
+					winston.error('[plugins/solr] Unable to add final data to solr. Error: ' + err.message);
+				}
+			});
+		} else {
+			winston.error('[plugins/solr] Could not retrieve topic listing for indexing. Error: ' + err.message);
+		}
 	});
 };
 


### PR DESCRIPTION
This is just as small error fix. In case there was an error while rebuilding the topic index it makes no sense to try to add any data to Solr. The chances even are that `results` might be undefined and thus further NodeJS errors are created.

Thus this checks if the topic index rebuild was successful and only then adds the data to Solr.