### PR TITLE
Compatibility With NodeBB v1.11.0. 

### DIFF
--- a/library.js
+++ b/library.js
@@ -2,18 +2,18 @@
 
 /* globals module, require */
 
-const db = module.parent.require('./database');
-const winston = module.parent.require('winston');
+const db = require.main.require('./src/database');
+const winston = require.main.require('winston');
 const engine = require('solr-client');
-const async = module.parent.require('async');
+const async = require.main.require('async');
 
 const LRU = require('lru-cache');
 const titleCache = LRU({ max: 20, maxAge: 1000 * 60 * 20 });	// Remember the last 20 searches in the past twenty minutes
 const postCache = LRU({ max: 20, maxAge: 1000 * 60 * 20 });	// Remember the last 20 searches in the past twenty minutes
 
-const topics = module.parent.require('./topics');
-const posts = module.parent.require('./posts');
-const batch = module.parent.require('./batch');
+const topics = require.main.require('./src/topics');
+const posts = require.main.require('./src/posts');
+const batch = require.main.require('./src/batch');
 const utils = require('./lib/utils');
 
 const Solr = {

--- a/middleware.js
+++ b/middleware.js
@@ -1,7 +1,7 @@
 'use strict';
 
 const Solr = module.parent.exports;
-const async = module.parent.parent.require('async');
+const async = require.main.require('async');
 
 const Middleware = {};
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nodebb-plugin-solr",
-  "version": "5.1.0",
+  "version": "5.1.1",
   "description": "Full-text searching for NodeBB using Apache Solr",
   "main": "library.js",
   "repository": {
@@ -32,6 +32,6 @@
     "eslint-plugin-import": "^2.8.0"
   },
   "nbbpm": {
-    "compatibility": "^1.5.0"
+    "compatibility": "^1.11.0"
   }
 }


### PR DESCRIPTION
To dismiss warning, to do :
* Use require.main.require instead of module.parent.require  (recommended by Node.js Docs & NodeBB Warning)