### PR TITLE
feat: support solr client secure option

### DIFF
--- a/library.js
+++ b/library.js
@@ -25,7 +25,8 @@ const Solr = {
 		path: '/solr'
 		enabled: undefined (false)
 		titleField: 'title_t'
-		contentField: 'description_t'
+		contentField: 'description_t',
+		secure: false
 	*/
 	config: {},	// default is localhost:8983, '' core, '/solr' path
 	client: undefined,
@@ -134,6 +135,11 @@ Solr.getTopicCount = function (callback) {
 Solr.connect = function () {
 	if (Solr.client) {
 		delete Solr.client;
+	}
+
+	Solr.config = {
+		...Solr.config,
+		secure: Solr.config.secure && Solr.config.secure === 'on'
 	}
 
 	Solr.client = engine.createClient(Solr.config);

--- a/templates/admin/plugins/solr.tpl
+++ b/templates/admin/plugins/solr.tpl
@@ -29,6 +29,10 @@
 							<label for="port">Port</label>
 							<input class="form-control" type="text" name="port" id="port" placeholder="8983" />
 						</div>
+							<div class="form-group col-sm-6">
+							<label for="port">Secure</label>
+							<input class="form-control" type="checkbox" name="secure" id="secure">
+						</div>
 						<div class="form-group col-sm-6">
 							<label for="path">Path</label>
 							<input class="form-control" type="text" name="path" id="path" placeholder="/solr" />

--- a/templates/admin/plugins/solr.tpl
+++ b/templates/admin/plugins/solr.tpl
@@ -29,10 +29,6 @@
 							<label for="port">Port</label>
 							<input class="form-control" type="text" name="port" id="port" placeholder="8983" />
 						</div>
-							<div class="form-group col-sm-6">
-							<label for="port">Secure</label>
-							<input class="form-control" type="checkbox" name="secure" id="secure">
-						</div>
 						<div class="form-group col-sm-6">
 							<label for="path">Path</label>
 							<input class="form-control" type="text" name="path" id="path" placeholder="/solr" />
@@ -40,6 +36,12 @@
 						<div class="form-group col-sm-6">
 							<label for="core">Core</label>
 							<input class="form-control" type="text" name="core" id="core" placeholder="" />
+						</div>
+						<div class="form-group col-sm-6">
+							<label for="secure">
+								<input type="checkbox" name="secure" id="secure" />
+								Secure
+							</label>
 						</div>
 					</div>
 


### PR DESCRIPTION
Support solr-client's `secure` options to enable the https connection with solr