### PR TITLE
feat: solr health check before search

### DIFF
--- a/library.js
+++ b/library.js
@@ -25,7 +25,8 @@ const Solr = {
 		path: '/solr'
 		enabled: undefined (false)
 		titleField: 'title_t'
-		contentField: 'description_t'
+		contentField: 'description_t',
+		secure: false
 	*/
 	config: {},	// default is localhost:8983, '' core, '/solr' path
 	client: undefined,
@@ -134,6 +135,11 @@ Solr.getTopicCount = function (callback) {
 Solr.connect = function () {
 	if (Solr.client) {
 		delete Solr.client;
+	}
+
+	Solr.config = {
+		...Solr.config,
+		secure: Solr.config.secure && Solr.config.secure === 'on'
 	}
 
 	Solr.client = engine.createClient(Solr.config);

--- a/library.js
+++ b/library.js
@@ -182,23 +182,31 @@ Solr.search = function (data, callback) {
 
 		const query = Solr.client.createQuery().q(term).edismax().qf(fields).start(0).rows(500);
 
-		Solr.client.search(query, function (err, obj) {
+		Solr.ping(function(err) {
 			if (err) {
-				return callback(err);
-			} else if (obj && obj.response && obj.response.docs.length > 0) {
-				const payload = obj.response.docs.map(function (result) {
-					return result[field];
-				}).filter(Boolean);
-
-				callback(null, payload);
-				cache.set(term, payload);
+				// Stop use search engine when connection failed
+				winston.error('[plugins/solr] Could not connect to Solr server' );
+				callback(null, data)
 			} else {
-				callback(null, []);
-				cache.set(term, []);
+				Solr.client.search(query, function(err, obj) {
+					if (err) {
+						return callback(err);
+					} else if (obj && obj.response && obj.response.docs.length > 0) {
+						const payload = obj.response.docs.map(function (result) {
+							return result[field];
+						}).filter(Boolean);
+		
+						callback(null, payload);
+						cache.set(term, payload);
+					} else {
+						callback(null, []);
+						cache.set(term, []);
+					}
+		
+					winston.verbose('[plugin/solr] Search (' + data.index + ') for "' + data.content + '" returned ' + obj.response.docs.length + ' results');
+				})
 			}
-
-			winston.verbose('[plugin/solr] Search (' + data.index + ') for "' + data.content + '" returned ' + obj.response.docs.length + ' results');
-		});
+		})
 	}
 };
 

--- a/library.js
+++ b/library.js
@@ -185,7 +185,7 @@ Solr.search = function (data, callback) {
 		Solr.ping(function(err) {
 			if (err) {
 				// Stop use search engine when connection failed
-				winston.error('[plugins/solr] Could not connect to Solr server' );
+				winston.warn('[plugins/solr] Could not connect to Solr server' );
 				callback(null, data)
 			} else {
 				Solr.client.search(query, function(err, obj) {

--- a/templates/admin/plugins/solr.tpl
+++ b/templates/admin/plugins/solr.tpl
@@ -29,6 +29,10 @@
 							<label for="port">Port</label>
 							<input class="form-control" type="text" name="port" id="port" placeholder="8983" />
 						</div>
+							<div class="form-group col-sm-6">
+							<label for="port">Secure</label>
+							<input class="form-control" type="checkbox" name="secure" id="secure">
+						</div>
 						<div class="form-group col-sm-6">
 							<label for="path">Path</label>
 							<input class="form-control" type="text" name="path" id="path" placeholder="/solr" />

--- a/templates/admin/plugins/solr.tpl
+++ b/templates/admin/plugins/solr.tpl
@@ -29,10 +29,6 @@
 							<label for="port">Port</label>
 							<input class="form-control" type="text" name="port" id="port" placeholder="8983" />
 						</div>
-							<div class="form-group col-sm-6">
-							<label for="port">Secure</label>
-							<input class="form-control" type="checkbox" name="secure" id="secure">
-						</div>
 						<div class="form-group col-sm-6">
 							<label for="path">Path</label>
 							<input class="form-control" type="text" name="path" id="path" placeholder="/solr" />
@@ -40,6 +36,12 @@
 						<div class="form-group col-sm-6">
 							<label for="core">Core</label>
 							<input class="form-control" type="text" name="core" id="core" placeholder="" />
+						</div>
+						<div class="form-group col-sm-6">
+							<label for="secure">
+								<input type="checkbox" name="secure" id="secure" />
+								Secure
+							</label>
 						</div>
 					</div>
 


### PR DESCRIPTION
I found if our solr server is not available, users would not be able to visit any topic either. The problem was caused by the *Suggested Topics Widget* in [nodebb-widget-essentials](nodebb-widget-essentials) plugin and we activated it in topic template, this widget will trigger a search if our search engine enabled: https://github.com/NodeBB/NodeBB/blob/master/src/topics/suggested.js#L72.

So before we do a search, we may need check service health first. @julianlam @Dravere 